### PR TITLE
修复upload-preview的image在h5环境下，没有宽度导致图片显示不全

### DIFF
--- a/packages/sard-uniapp/src/components/upload-preview/upload-preview.vue
+++ b/packages/sard-uniapp/src/components/upload-preview/upload-preview.vue
@@ -2,6 +2,7 @@
   <view :class="uploadPreviewClass" :style="uploadPreviewStyle">
     <image
       v-if="isImage"
+      :class="bem.e('image')"
       mode="aspectFill"
       :src="mediaUrl"
       @click="onImageClick"


### PR DESCRIPTION
fix: 修复upload-preview的image在h5环境下，没有宽度导致图片显示不全

解决方案，给image添加class

![image](https://github.com/sutras/sard-uniapp/assets/21304258/bcf1fd1e-709d-46ae-8239-51927aad08a9)

添加class后

![image](https://github.com/sutras/sard-uniapp/assets/21304258/8e55396b-2840-4d5b-99a7-b117325cbedc)
