### PR TITLE
docs: fix emit's name of Keyboard

### DIFF
--- a/packages/sard-uniapp/src/components/keyboard/README.md
+++ b/packages/sard-uniapp/src/components/keyboard/README.md
@@ -57,7 +57,7 @@ import Keyboard from 'sard-uniapp/components/keyboard/keyboard.vue'
 | 事件      | 描述                 | 类型                  |
 | --------- | -------------------- | --------------------- |
 | input     | 可输入按键点击时触发 | (key: string) => void |
-| backspace | 点击删除按钮时触发   | () => void            |
+| delete    | 点击删除按钮时触发   | () => void            |
 
 ### KeyBoardExpose
 


### PR DESCRIPTION
before:

| 事件      | 描述                 | 类型                  |
| --------- | -------------------- | --------------------- |
| input     | 可输入按键点击时触发 | (key: string) => void |
| backspace | 点击删除按钮时触发   | () => void            |

after:

| 事件      | 描述                 | 类型                  |
| --------- | -------------------- | --------------------- |
| input     | 可输入按键点击时触发 | (key: string) => void |
| delete    | 点击删除按钮时触发   | () => void            |