### PR TITLE
feat(input): 添加 enableNative 属性以支持支付宝小程序

### DIFF
--- a/src/lib/components/config/index.ts
+++ b/src/lib/components/config/index.ts
@@ -237,6 +237,7 @@ export const defaultConfig = {
     hintDuration: 300,
   },
   input: {
+    enableNative: false,
     maxlength: 140,
     adjustPosition: true,
     ignoreCompositionEvent: true,

--- a/src/lib/components/input/common.ts
+++ b/src/lib/components/input/common.ts
@@ -2,6 +2,8 @@ import { type StyleValue } from 'vue'
 import { defaultConfig } from '../config'
 
 export interface InputProps {
+  // 现支付宝小程序特有属性详情请查看: https://opendocs.alipay.com/mini/component/input
+  enableNative?: boolean
   placeholder?: string
   placeholderStyle?: string
   placeholderClass?: string

--- a/src/lib/components/input/input.vue
+++ b/src/lib/components/input/input.vue
@@ -16,10 +16,11 @@
             bem.em('control', 'input-min-height', inputMinHeight),
           )
         "
+        :enableNative="enableNative"
+        :value="innerValue"
         :placeholder="placeholder"
         :placeholder-style="mergedPlaceholderStyle"
         :placeholder-class="placeholderClass"
-        :value="innerValue"
         :disabled="isDisabled || isReadonly"
         :maxlength="maxlength"
         :focus="focus"
@@ -51,6 +52,7 @@
       <input
         v-if="type !== 'textarea' && showPassword"
         :class="classNames(bem.e('control'), bem.em('control', 'input'))"
+        :enableNative="enableNative"
         :value="innerValue"
         :placeholder="placeholder"
         :placeholder-style="mergedPlaceholderStyle"
@@ -91,6 +93,7 @@
       <input
         v-if="type !== 'textarea' && !showPassword"
         :class="classNames(bem.e('control'), bem.em('control', 'input'))"
+        :enableNative="enableNative"
         :value="innerValue"
         :placeholder="placeholder"
         :placeholder-style="mergedPlaceholderStyle"
@@ -321,8 +324,6 @@ const showPassword = computed(() => {
   return props.type === 'password' && isPlainText.value === false
 })
 
-const mergedShowEye = computed(() => props.type === 'password' && props.showEye)
-
 const mergedType = computed(() => {
   return showPassword.value
     ? 'password'
@@ -330,6 +331,8 @@ const mergedType = computed(() => {
       ? 'text'
       : props.type
 })
+
+const mergedShowEye = computed(() => props.type === 'password' && props.showEye)
 
 // others
 const inputClass = computed(() => {


### PR DESCRIPTION
处理 #229 
- 在 defaultConfig 中添加 enableNative 属性，默认值为 false
- 在 InputProps 接口中添加 enableNative 属性，用于支付宝小程序的特有功能
- 在 input.vue 组件中为 input 元素添加 enableNative 属性
- 调整 mergedShowEye 计算属性的位置，提高代码可读性