### PR TITLE
feat(keyboard): 扩展键盘toggle方法支持传入mode参数

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "id": "sard-uniapp",
   "name": "sard-uniapp",
   "displayName": "sard-uniapp",
-  "version": "1.23.5",
+  "version": "1.23.6",
   "description": "sard-uniapp 是一套基于 Uniapp + Vue3 框架开发的兼容多端的 UI 组件库",
   "main": "index.js",
   "scripts": {
@@ -97,6 +97,7 @@
     "@dcloudio/uni-stacktracey": "3.0.0-4060420250429001",
     "@dcloudio/vite-plugin-uni": "3.0.0-4060420250429001",
     "@esbuild/darwin-x64": "0.25.4",
+    "@eslint/js": "^9.33.0",
     "@gunny/perf-test": "^0.1.3",
     "@rollup/rollup-darwin-x64": "^4.24.0",
     "@types/inquirer": "^9.0.7",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - core-js
+  - esbuild

--- a/src/lib/components/keyboard/README.md
+++ b/src/lib/components/keyboard/README.md
@@ -51,26 +51,26 @@ import Keyboard from 'sard-uniapp/components/keyboard/keyboard.vue'
 
 ### KeyboardProps
 
-| 属性       | 描述           | 类型                                                   | 默认值   |
-| ---------- | -------------- | ------------------------------------------------------ | -------- |
-| root-class | 组件根元素类名 | string                                                 | -        |
-| root-style | 组件根元素样式 | StyleValue                                             | -        |
-| type       | 键盘类型       | 'number' \| 'digit' \| 'idcard' \| 'random' \| 'plate' | 'number' |
+| 属性       | 描述           | 类型                                                  | 默认值   |
+| ---------- | -------------- | ----------------------------------------------------- | -------- |
+| root-class | 组件根元素类名 | string                                                | -        |
+| root-style | 组件根元素样式 | StyleValue                                            | -        |
+| type       | 键盘类型       | 'number'\| 'digit' \| 'idcard' \| 'random' \| 'plate' | 'number' |
 
 ### KeyboardEmits
 
-| 事件                      | 描述                     | 类型                                   |
-| ------------------------- | ------------------------ | -------------------------------------- |
-| input                     | 可输入按键点击时触发     | (key: string) => void                  |
-| delete                    | 点击删除按钮时触发       | () => void                             |
-| toggle <sup>1.23.3+</sup> | 切换车牌号的中英文时触发 | (mode: 'chinese' \| 'english') => void |
+| 事件                      | 描述                     | 类型                                  |
+| ------------------------- | ------------------------ | ------------------------------------- |
+| input                     | 可输入按键点击时触发     | (key: string) => void                 |
+| delete                    | 点击删除按钮时触发       | () => void                            |
+| toggle <sup>1.23.3+</sup> | 切换车牌号的中英文时触发 | (mode: 'chinese'\| 'english') => void |
 
 ### KeyBoardExpose
 
-| 属性    | 描述                   | 类型       |
-| ------- | ---------------------- | ---------- |
-| shuffle | 重新打乱随机键盘按键   | () => void |
-| toggle  | 切换车牌号的中英文按键 | () => void |
+| 属性                      | 描述                                 | 类型                                   |
+| ------------------------- | ------------------------------------ | -------------------------------------- |
+| shuffle                   | 重新打乱随机键盘按键                 | () => void                             |
+| toggle <sup>1.23.6+</sup> | 切换车牌号的中英文按键，可选传入mode | (mode?: 'chinese'\| 'english') => void |
 
 ## 主题定制
 

--- a/src/lib/components/keyboard/common.ts
+++ b/src/lib/components/keyboard/common.ts
@@ -22,7 +22,7 @@ export interface KeyboardEmits {
 
 export interface KeyBoardExpose {
   shuffle: () => void
-  toggle: () => void
+  toggle: (mode?: KeyboardPlateMode) => void
 }
 
 export const numberKeys = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0']

--- a/src/lib/components/keyboard/keyboard.vue
+++ b/src/lib/components/keyboard/keyboard.vue
@@ -87,7 +87,7 @@
         <view
           :class="toggleClass"
           :style="`order: ${interceptOrder}`"
-          @click="onToggle"
+          @click="onToggle()"
         >
           <view :class="bem.e('key')">
             {{ toggleKey }}
@@ -150,8 +150,8 @@ defineExpose<KeyBoardExpose>({
   shuffle() {
     randomKeys.value = getRandomKeys()
   },
-  toggle() {
-    onToggle()
+  toggle(mode: KeyboardPlateMode) {
+    onToggle(mode)
   },
 })
 
@@ -187,8 +187,8 @@ const interceptOrder = computed(() => {
   return chineseKeys.length - (overflow > 7 ? 0 : overflow + 1)
 })
 
-const onToggle = () => {
-  mode.value = mode.value === 'chinese' ? 'english' : 'chinese'
+const onToggle = (newMode?: KeyboardPlateMode) => {
+  mode.value = newMode || (mode.value === 'chinese' ? 'english' : 'chinese')
   emit('toggle', mode.value)
 }
 

--- a/src/pages/components/keyboard/demo/Plate.vue
+++ b/src/pages/components/keyboard/demo/Plate.vue
@@ -1,3 +1,18 @@
 <template>
-  <sar-keyboard type="plate" />
+  <view class="flex gap-[10rpx] mb-[10rpx]">
+    <sar-button inline @click="plateKeyboard?.toggle('chinese')">
+      设置为中文
+    </sar-button>
+    <sar-button inline @click="plateKeyboard?.toggle('english')">
+      设置为英文
+    </sar-button>
+  </view>
+  <sar-keyboard ref="plateKeyboard" type="plate" />
 </template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { KeyBoardExpose } from 'sard-uniapp'
+
+const plateKeyboard = ref<KeyBoardExpose>()
+</script>


### PR DESCRIPTION
- 修改KeyboardExpose接口，使toggle方法支持可选mode参数
- 更新键盘组件实现以支持外部控制中英文切换
- 添加demo展示如何通过toggle方法设置键盘模式
- 更新README文档说明新增功能
- 更新package.json版本号至1.23.6
- 添加pnpm-workspace.yaml配置文件和@eslint/js依赖