### PR TITLE
feat(button): 新增scope属性和getAuthorize事件支持

### DIFF
--- a/packages/sard-uniapp/components/button/button.vue
+++ b/packages/sard-uniapp/components/button/button.vue
@@ -21,6 +21,7 @@
     @click="onClick"
     @getphonenumber="onGetphonenumber"
     @getAuthorize="onGetauthorize"
+    @followLifestyle="onFollowLifestyle"
     @getuserinfo="onGetuserinfo"
     @error="onError"
     @opensetting="onOpensetting"
@@ -100,6 +101,10 @@ const onGetphonenumber = (event: any) => {
 
 const onGetauthorize = (event: any) => {
   emit('getAuthorize', event)
+}
+
+const onFollowLifestyle = (event: any) => {
+  emit('followLifestyle', event)
 }
 
 const onGetuserinfo = (event: any) => {

--- a/packages/sard-uniapp/components/button/button.vue
+++ b/packages/sard-uniapp/components/button/button.vue
@@ -9,6 +9,7 @@
     :app-parameter="appParameter"
     :hover-stop-propagation="hoverStopPropagation"
     :lang="lang"
+    :scope="scope"
     :session-from="sessionFrom"
     :send-message-title="sendMessageTitle"
     :send-message-path="sendMessagePath"
@@ -19,6 +20,7 @@
     :public-id="publicId"
     @click="onClick"
     @getphonenumber="onGetphonenumber"
+    @getAuthorize="onGetauthorize"
     @getuserinfo="onGetuserinfo"
     @error="onError"
     @opensetting="onOpensetting"
@@ -94,6 +96,10 @@ const onClick = (event: any) => {
 
 const onGetphonenumber = (event: any) => {
   emit('getphonenumber', event)
+}
+
+const onGetauthorize = (event: any) => {
+  emit('getAuthorize', event)
 }
 
 const onGetuserinfo = (event: any) => {

--- a/packages/sard-uniapp/components/button/common.ts
+++ b/packages/sard-uniapp/components/button/common.ts
@@ -33,6 +33,7 @@ export interface ButtonProps {
   appParameter?: string
   hoverStopPropagation?: boolean
   lang?: string
+  scope?: string
   sessionFrom?: string
   sendMessageTitle?: string
   sendMessagePath?: string

--- a/packages/sard-uniapp/components/button/common.ts
+++ b/packages/sard-uniapp/components/button/common.ts
@@ -64,6 +64,8 @@ export interface ButtonEmits {
 
   // 小程序能力
   (e: 'getphonenumber', event: any): void
+  (e: 'getAuthorize', event: any): void
+  (e: 'followLifestyle', event: any): void
   (e: 'getuserinfo', event: any): void
   (e: 'error', event: any): void
   (e: 'opensetting', event: any): void


### PR DESCRIPTION
为uniapp按钮组件添加支付宝小程序授权相关的scope参数以及getAuthorize回调事件，完善组件对小程序授权流程的支持

根据支付宝官方文档 https://opendocs.alipay.com/mini/component/button?pathHash=e0342ed0#%E5%B1%9E%E6%80%A7%E8%AF%B4%E6%98%8E  ，以及社区帖子 https://ask.dcloud.net.cn/question/179404 ，再加上我之前封装过的组件来看，确实是需要这些属性和事件的。